### PR TITLE
Suggestion for not wrapping ServerManagedPropertyExceptions

### DIFF
--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/MalformedRdfExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/MalformedRdfExceptionMapper.java
@@ -17,7 +17,6 @@ package org.fcrepo.http.commons.exceptionhandlers;
 
 import static javax.ws.rs.core.Response.status;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static javax.ws.rs.core.Response.Status.CONFLICT;
 import static org.fcrepo.kernel.RdfLexicon.CONSTRAINED_BY;
 
 import javax.ws.rs.core.Link;
@@ -40,9 +39,6 @@ public class MalformedRdfExceptionMapper implements ExceptionMapper<MalformedRdf
         final Link link = Link.fromUri(getConstraintUri(e)).rel(CONSTRAINED_BY.getURI()).build();
         final String msg = e.getMessage();
 
-        if (msg.contains("server-managed predicate")) {
-            return status(CONFLICT).entity(msg).links(link).build();
-        }
         if (msg.matches(".*org.*Exception: .*")) {
             return status(BAD_REQUEST).entity(msg.replaceAll("org.*Exception: ", "")).links(link).build();
         }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/utils/iterators/PersistingRdfStreamConsumer.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/utils/iterators/PersistingRdfStreamConsumer.java
@@ -21,6 +21,7 @@ import static org.fcrepo.kernel.impl.rdf.ManagedRdf.isManagedMixin;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import com.google.common.base.Joiner;
+import org.fcrepo.kernel.exception.ServerManagedPropertyException;
 import org.fcrepo.kernel.models.FedoraResource;
 import org.fcrepo.kernel.exception.MalformedRdfException;
 import org.fcrepo.kernel.exception.RepositoryRuntimeException;
@@ -146,6 +147,8 @@ public abstract class PersistingRdfStreamConsumer implements RdfStreamConsumer {
                         t);
                 operateOnProperty(t, subjectNode);
             }
+        } catch (ServerManagedPropertyException smpe) {
+            throw smpe;
         } catch (final RepositoryException | RepositoryRuntimeException e) {
             throw new MalformedRdfException(e.getMessage(), e);
         }


### PR DESCRIPTION
The tests need to be updated for this change, and a new test should be added to `FedoraLdpIT` that tries to add a fedora-namespaced property, such as `fedora:junk = "hello"`
