### PR TITLE
Update root-authorization.ttl so that it will cover the repository root.

### DIFF
--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
@@ -22,6 +22,7 @@ import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.apache.jena.graph.Triple.create;
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.apache.jena.riot.Lang.TTL;
+import static org.fcrepo.auth.webac.URIConstants.FOAF_AGENT_VALUE;
 import static org.fcrepo.auth.webac.URIConstants.VCARD_GROUP;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_ACCESS_CONTROL_VALUE;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_MODE_READ_VALUE;
@@ -130,6 +131,11 @@ public class WebACRolesProviderTest {
         when(mockNode.getDepth()).thenReturn(0);
     }
 
+    private void assertOnlyDefaultAgentInRoles(final Map<String, Collection<String>> roles) {
+        assertEquals(1, roles.size());
+        assertTrue(roles.keySet().contains(FOAF_AGENT_VALUE));
+    }
+
     @Test
     public void noAclTest() throws RepositoryException {
         final String accessTo = "/dark/archive/sunshine";
@@ -153,7 +159,7 @@ public class WebACRolesProviderTest {
 
         final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
 
-        assertTrue("There should be no agents in the roles map", roles.isEmpty());
+        assertOnlyDefaultAgentInRoles(roles);
     }
 
     @Test
@@ -285,7 +291,7 @@ public class WebACRolesProviderTest {
 
         final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
 
-        assertTrue("There should be no agents associated with this object", roles.isEmpty());
+        assertOnlyDefaultAgentInRoles(roles);
     }
 
     @Test
@@ -597,7 +603,7 @@ public class WebACRolesProviderTest {
 
         final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
 
-        assertEquals("There should be exactly zero agents", 0, roles.size());
+        assertOnlyDefaultAgentInRoles(roles);
     }
 
     @Test

--- a/fcrepo-http-api/src/main/resources/root-authorization.ttl
+++ b/fcrepo-http-api/src/main/resources/root-authorization.ttl
@@ -2,11 +2,14 @@
 @prefix acl: <http://www.w3.org/ns/auth/acl#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix fedora: <http://fedora.info/definitions/v4/repository#> .
+@prefix webac: <http://fedora.info/definitions/v4/webac#> .
 
-<> a acl:Authorization ;
+<info:fedora/fcr:acl> a webac:Acl .
+
+<info:fedora/fcr:acl#authz> a acl:Authorization ;
    rdfs:label "Root Authorization" ;
-   rdfs:comment "By default, all non-Admin agents (foaf:Agent) are denied access (no acl:mode is specified) to all resources." ;
+   rdfs:comment "By default, all non-Admin agents (foaf:Agent) only have read access (acl:Read) to the respository" ;
    acl:agentClass foaf:Agent ;
    acl:mode acl:Read ;
-   acl:accessToClass fedora:Resource ;
-   acl:default <.> .
+   acl:accessTo <info:fedora/> ;
+   acl:default <info:fedora/> .

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraAclIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraAclIT.java
@@ -214,17 +214,29 @@ public class FedoraAclIT extends AbstractResourceIT {
     @Test
     public void testGetDefaultRootAcl() throws Exception {
         final String rootAclUri = serverAddress + FCR_ACL;
+        final String rootFedoraUri = "info:fedora/";
+        final String authzUri = rootFedoraUri + FCR_ACL + "#authz";
         try (final CloseableDataset dataset = getDataset(new HttpGet(rootAclUri))) {
             final DatasetGraph graph = dataset.asDatasetGraph();
             assertTrue(graph.contains(ANY,
-                                      createURI(rootAclUri),
-                                      createURI("http://www.w3.org/2000/01/rdf-schema#label"),
-                                      createLiteral("Root Authorization")));
+                    createURI(authzUri),
+                    createURI("http://www.w3.org/2000/01/rdf-schema#label"),
+                    createLiteral("Root Authorization")));
 
             assertTrue(graph.contains(ANY,
-                                      createURI(rootAclUri),
-                                      createURI(WEBAC_NAMESPACE_VALUE + "default"),
-                                      createURI(serverAddress)));
+                    createURI(authzUri),
+                    createURI(WEBAC_NAMESPACE_VALUE + "default"),
+                    createURI(rootFedoraUri)));
+
+            assertTrue(graph.contains(ANY,
+                    createURI(authzUri),
+                    createURI(WEBAC_NAMESPACE_VALUE + "accessTo"),
+                    createURI(rootFedoraUri)));
+
+            assertTrue(graph.contains(ANY,
+                    createURI(authzUri),
+                    createURI(WEBAC_NAMESPACE_VALUE + "mode"),
+                    createURI(WEBAC_NAMESPACE_VALUE + "Read")));
         }
     }
 


### PR DESCRIPTION
Use the non-server-specific "info:fedora/" URI scheme to be server agnostic. Also updated the tests to take into account there is a non-empty backstop ACL now.
